### PR TITLE
Split OpenGLES into 3.0 and 3.2

### DIFF
--- a/Furball.Vixie.Backends.OpenGLES/Furball.Vixie.Backends.OpenGLES.csproj
+++ b/Furball.Vixie.Backends.OpenGLES/Furball.Vixie.Backends.OpenGLES.csproj
@@ -31,6 +31,8 @@
     </ItemGroup>
 
     <ItemGroup>
+      <EmbeddedResource Include="Shaders\LineRenderer\FragmentShader30.glsl" />
+      <EmbeddedResource Include="Shaders\LineRenderer\VertexShader30.glsl" />
       <EmbeddedResource Include="Shaders\QuadRenderer\FragmentShader.glsl" />
       <EmbeddedResource Include="Shaders\QuadRenderer\VertexShader.glsl" />
         

--- a/Furball.Vixie.Backends.OpenGLES/LineRendererGLES30.cs
+++ b/Furball.Vixie.Backends.OpenGLES/LineRendererGLES30.cs
@@ -25,6 +25,8 @@ namespace Furball.Vixie.Backends.OpenGLES {
         private          int        _batchedLines = 0;
         private readonly LineData[] _lineData     = new LineData[BATCH_MAX];
         
+        public bool IsBegun { get; set; }
+        
         internal unsafe LineRendererGLES30(OpenGLESBackend backend) {
             this._backend = backend;
             this._gl      = backend.GetGLES();
@@ -52,10 +54,7 @@ namespace Furball.Vixie.Backends.OpenGLES {
         ~LineRendererGLES30() {
             DisposeQueue.Enqueue(this._program);
         }
-        public bool IsBegun {
-            get;
-            set;
-        }
+        
         public unsafe void Begin() {
             this.IsBegun = true;
             

--- a/Furball.Vixie.Backends.OpenGLES/LineRendererGLES30.cs
+++ b/Furball.Vixie.Backends.OpenGLES/LineRendererGLES30.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Numerics;
+using Furball.Vixie.Backends.OpenGL.Shared;
+using Furball.Vixie.Backends.Shared;
+using Furball.Vixie.Backends.Shared.Renderers;
+using Furball.Vixie.Helpers;
+using Furball.Vixie.Helpers.Helpers;
+using Silk.NET.OpenGLES;
+using GL=Silk.NET.OpenGLES.GL;
+
+namespace Furball.Vixie.Backends.OpenGLES {
+    public class LineRendererGLES30 : ILineRenderer {
+        private struct LineData {
+            public Vector2 Position;
+            public Color   Color;
+        }
+        
+        private readonly OpenGLESBackend _backend;
+
+        private const int BATCH_MAX = 128; //cut this in two for actual line count, as we use 2 LineData structs per line :^)
+        
+        private readonly ShaderGL _program;
+        private readonly uint        _arrayBuf;
+
+        private          int        _batchedLines = 0;
+        private readonly LineData[] _lineData     = new LineData[BATCH_MAX];
+        
+        internal unsafe LineRendererGLES30(OpenGLESBackend backend) {
+            this._backend = backend;
+            this._gl      = backend.GetGLES();
+            
+            string vertex   = ResourceHelpers.GetStringResource("Shaders/LineRenderer/VertexShader30.glsl");
+            string fragment = ResourceHelpers.GetStringResource("Shaders/LineRenderer/FragmentShader30.glsl");
+
+            this._program = new ShaderGL(backend);
+
+            this._program.AttachShader(ShaderType.VertexShader, vertex)
+                         .AttachShader(ShaderType.FragmentShader, fragment)
+                         .Link();
+
+            this._arrayBuf = this._gl.GenBuffer();
+            this._gl.BindBuffer(BufferTargetARB.ArrayBuffer, this._arrayBuf);
+            //Fill the buffer with empty
+            this._gl.BufferData(BufferTargetARB.ArrayBuffer, (nuint)(sizeof(LineData) * BATCH_MAX), null, BufferUsageARB.DynamicDraw);
+            
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, 0);
+        }
+
+        public void Dispose() {
+            
+        }
+        ~LineRendererGLES30() {
+            DisposeQueue.Enqueue(this._program);
+        }
+        public bool IsBegun {
+            get;
+            set;
+        }
+        public unsafe void Begin() {
+            this.IsBegun = true;
+            
+            this._program.Bind();
+
+            fixed (void* ptr = &this._backend.ProjectionMatrix)
+                this._gl.UniformMatrix4(this._program.GetUniformLocation("u_ProjectionMatrix"), 1, false, (float*)ptr);
+            this._backend.CheckError("uniform matrix 4");
+            
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, this._arrayBuf);
+            
+            this._gl.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, (uint)sizeof(LineData), (void*)0);
+            this._gl.VertexAttribPointer(1, 4, VertexAttribPointerType.Float, false, (uint)sizeof(LineData), (void*)sizeof(Vector2));
+            
+            this._gl.EnableVertexAttribArray(0);
+            this._gl.EnableVertexAttribArray(1);
+            
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, 0);
+            
+            this._program.Unbind();
+        }
+
+        private          float       lastThickness = 0;
+        private readonly GL          _gl;
+        public void Draw(Vector2 begin, Vector2 end, float thickness, Color color) {
+            if (!this.IsBegun) throw new Exception("LineRenderer is not begun!!");
+
+            if (thickness == 0 || color.A == 0) return;
+
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (thickness != this.lastThickness || this._batchedLines == BATCH_MAX) {
+                this.Flush();
+                this.lastThickness = thickness;
+            }
+
+            this._lineData[this._batchedLines].Position     = begin;
+            this._lineData[this._batchedLines + 1].Position = end;
+            this._lineData[this._batchedLines].Color        = color;
+            this._lineData[this._batchedLines + 1].Color    = color;
+
+            this._batchedLines += 2;
+        }
+
+        private unsafe void Flush() {
+            if (this._batchedLines == 0 || this.lastThickness == 0) return;
+
+            //Bind program
+            this._program.Bind();
+            //Bind the buffer with our batched lines
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, this._arrayBuf);
+            
+            //Buffer the data
+            this._gl.BufferSubData<LineData>(GLEnum.ArrayBuffer, 0, (nuint)(this._batchedLines * sizeof(LineData)), this._lineData);
+
+            this._gl.LineWidth(this.lastThickness);
+            this._gl.DrawArrays(PrimitiveType.Lines, 0, (uint)this._batchedLines);
+
+            //Unbind buffer
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, 0);
+            //Unbind program
+            this._program.Unbind();
+
+            this._batchedLines = 0;
+            this.lastThickness = 0;
+        }
+        
+        public void End() {
+            this.IsBegun = false;
+            this.Flush();
+
+            this._program.Bind();
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, this._arrayBuf);
+
+            this._gl.DisableVertexAttribArray(0);
+            this._gl.DisableVertexAttribArray(1);
+            
+            this._gl.BindBuffer(GLEnum.ArrayBuffer, 0);
+            this._program.Unbind();
+        }
+    }
+}

--- a/Furball.Vixie.Backends.OpenGLES/LineRendererGLES32.cs
+++ b/Furball.Vixie.Backends.OpenGLES/LineRendererGLES32.cs
@@ -14,7 +14,7 @@ namespace Furball.Vixie.Backends.OpenGLES {
         public fixed float Color[4];
     }
 
-    public class LineRendererGLES : IDisposable, ILineRenderer {
+    public class LineRendererGLES32 : IDisposable, ILineRenderer {
         private readonly OpenGLESBackend _backend;
         /// <summary>
         /// Max Lines allowed in 1 Batch
@@ -55,7 +55,7 @@ namespace Furball.Vixie.Backends.OpenGLES {
         /// </summary>
         /// <param name="backend">OpenGLES API</param>
         /// <param name="capacity">How many Lines to allow in 1 Batch</param>
-        public unsafe LineRendererGLES(OpenGLESBackend backend, int capacity = 8192) {
+        public unsafe LineRendererGLES32(OpenGLESBackend backend, int capacity = 8192) {
             this._backend = backend;
             this.gl       = backend.GetGlApi();
 

--- a/Furball.Vixie.Backends.OpenGLES/OpenGLESBackend.cs
+++ b/Furball.Vixie.Backends.OpenGLES/OpenGLESBackend.cs
@@ -72,8 +72,14 @@ namespace Furball.Vixie.Backends.OpenGLES {
             if (Thread.CurrentThread != _mainThread)
                 throw new ThreadStateException("You are calling GL on the wrong thread!");
         }
-        internal IWindow Window;
-        private  bool    _screenshotQueued;
+        internal         IWindow Window;
+        private          bool    _screenshotQueued;
+        private readonly bool    Is32;
+
+        public OpenGLESBackend(bool is32) {
+            this.Is32 = is32;
+        }
+        
         /// <summary>
         /// Used to Initialize the Backend
         /// </summary>
@@ -167,7 +173,9 @@ namespace Furball.Vixie.Backends.OpenGLES {
         /// </summary>
         /// <returns></returns>
         public override ILineRenderer CreateLineRenderer() {
-            return new LineRendererGLES(this);
+            return this.Is32 ? 
+                       new LineRendererGLES32(this) : 
+                       new LineRendererGLES30(this);
         }
         /// <summary>
         /// Gets the Amount of Texture Units available for use

--- a/Furball.Vixie.Backends.OpenGLES/QuadRendererGLES.cs
+++ b/Furball.Vixie.Backends.OpenGLES/QuadRendererGLES.cs
@@ -100,6 +100,7 @@ namespace Furball.Vixie.Backends.OpenGLES {
             this._vbo = new BufferObjectGL(backend, BufferTargetARB.ArrayBuffer, BufferUsageARB.StaticDraw);
             this._vbo.Bind();
             this._vbo.SetData<Vertex>(_vertices);
+            this._backend.CheckError("fill vert buff");
 
             //Vertex Position
             this.gl.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, (uint)sizeof(Vertex), (void*)0);
@@ -184,6 +185,17 @@ namespace Furball.Vixie.Backends.OpenGLES {
 
             this._shaderGles.SetUniform("vx_WindowProjectionMatrix", this._backend.ProjectionMatrix);
 
+            this.gl.EnableVertexAttribArray(0);
+            this.gl.EnableVertexAttribArray(1);
+            this.gl.EnableVertexAttribArray(2);
+            this.gl.EnableVertexAttribArray(3);
+            this.gl.EnableVertexAttribArray(4);
+            this.gl.EnableVertexAttribArray(5);
+            this.gl.EnableVertexAttribArray(6);
+            this.gl.EnableVertexAttribArray(7);
+            this.gl.EnableVertexAttribArray(8);
+            this.gl.EnableVertexAttribArray(9);
+            
             this._instances = 0;
             this._usedTextures = 0;
 
@@ -303,11 +315,15 @@ namespace Furball.Vixie.Backends.OpenGLES {
             this._backend.CheckError("Bind vao");
 
             // this._InstanceVBO.SetData<InstanceData>(this._instanceData);
+            this._vbo.Bind();
             this._instanceVbo.Bind();
             fixed (void* ptr = this._instanceData)
                 this._instanceVbo.SetSubData(ptr, (nuint)(this._instances * sizeof(InstanceData)));
 
             this.gl.DrawElementsInstanced<ushort>(PrimitiveType.TriangleStrip, 6, DrawElementsType.UnsignedShort, _indicies, this._instances);
+
+            this._vao.Unbind();
+            this._vbo.Unbind();
 
             this._instances    = 0;
             this._usedTextures = 0;
@@ -316,6 +332,17 @@ namespace Furball.Vixie.Backends.OpenGLES {
         public void End() {
             this.Flush();
             this.IsBegun = false;
+            
+            this.gl.DisableVertexAttribArray(0);
+            this.gl.DisableVertexAttribArray(1);
+            this.gl.DisableVertexAttribArray(2);
+            this.gl.DisableVertexAttribArray(3);
+            this.gl.DisableVertexAttribArray(4);
+            this.gl.DisableVertexAttribArray(5);
+            this.gl.DisableVertexAttribArray(6);
+            this.gl.DisableVertexAttribArray(7);
+            this.gl.DisableVertexAttribArray(8);
+            this.gl.DisableVertexAttribArray(9);
         }
 
         #region text

--- a/Furball.Vixie.Backends.OpenGLES/Shaders/LineRenderer/FragmentShader30.glsl
+++ b/Furball.Vixie.Backends.OpenGLES/Shaders/LineRenderer/FragmentShader30.glsl
@@ -1,0 +1,10 @@
+#version 300 es
+precision highp float;
+
+in vec4 fs_in_col;
+
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+    frag_color = fs_in_col;
+}

--- a/Furball.Vixie.Backends.OpenGLES/Shaders/LineRenderer/GeometryShader.glsl
+++ b/Furball.Vixie.Backends.OpenGLES/Shaders/LineRenderer/GeometryShader.glsl
@@ -1,6 +1,4 @@
 #version 320 es
-#extension GL_EXT_geometry_shader : enable
-#extension GL_OES_geometry_shader : enable
 precision highp float;
 
 layout(lines) in;

--- a/Furball.Vixie.Backends.OpenGLES/Shaders/LineRenderer/VertexShader30.glsl
+++ b/Furball.Vixie.Backends.OpenGLES/Shaders/LineRenderer/VertexShader30.glsl
@@ -1,0 +1,13 @@
+#version 300 es
+
+layout(location = 0) in vec2 a_VertexPosition;
+layout(location = 1) in vec4 a_VertexColor;
+
+uniform mat4 u_ProjectionMatrix;
+
+out vec4 fs_in_col;
+
+void main() {
+    gl_Position = u_ProjectionMatrix * vec4(a_VertexPosition, 0, 1);
+    fs_in_col = a_VertexColor;
+}

--- a/Furball.Vixie.Backends.Shared/Backends/Backend.cs
+++ b/Furball.Vixie.Backends.Shared/Backends/Backend.cs
@@ -5,11 +5,12 @@ using System;
 namespace Furball.Vixie.Backends.Shared.Backends {
     [Flags]
     public enum Backend {
-        None       = 1 << 0, //Not a real backend
+        None       = 1 << 0,//Not a real backend
         Direct3D11 = 1 << 1,
         OpenGL20   = 1 << 2,
         OpenGL41   = 1 << 3,
-        OpenGLES   = 1 << 4,
-        Veldrid    = 1 << 5,
+        OpenGLES30 = 1 << 4,
+        OpenGLES32 = 1 << 5,
+        Veldrid    = 1 << 6,
     }
 }

--- a/Furball.Vixie.TestApplication/Program.cs
+++ b/Furball.Vixie.TestApplication/Program.cs
@@ -8,7 +8,7 @@ var options = WindowOptions.Default;
 
 options.VSync = false;
 
-GraphicsBackend.PrefferedBackends = Backend.Veldrid;
+GraphicsBackend.PrefferedBackends = Backend.OpenGLES;
 
 VeldridBackend.PrefferedBackend = Veldrid.GraphicsBackend.Vulkan;
 

--- a/Furball.Vixie.TestApplication/Program.cs
+++ b/Furball.Vixie.TestApplication/Program.cs
@@ -8,7 +8,7 @@ var options = WindowOptions.Default;
 
 options.VSync = false;
 
-GraphicsBackend.PrefferedBackends = Backend.OpenGLES;
+GraphicsBackend.PrefferedBackends = Backend.OpenGL41 | Backend.OpenGLES32;
 
 VeldridBackend.PrefferedBackend = Veldrid.GraphicsBackend.Vulkan;
 

--- a/Furball.Vixie/GraphicsBackend.cs
+++ b/Furball.Vixie/GraphicsBackend.cs
@@ -22,7 +22,8 @@ namespace Furball.Vixie {
         /// <exception cref="ArgumentOutOfRangeException">Throws if a Invalid API was chosen</exception>
         public static void SetBackend(Backend backend) {
             Current = backend switch {
-                Backend.OpenGLES   => new OpenGLESBackend(),
+                Backend.OpenGLES30 => new OpenGLESBackend(false),
+                Backend.OpenGLES32 => new OpenGLESBackend(true),
                 Backend.Direct3D11 => new Direct3D11Backend(),
                 Backend.OpenGL20   => new OpenGL20Backend(),
                 Backend.OpenGL41   => new OpenGL41Backend(),
@@ -38,7 +39,8 @@ namespace Furball.Vixie {
             bool preferVeldridOverNative  = PrefferedBackends.HasFlag(Backend.Veldrid);
             bool preferOpenGl             = PrefferedBackends.HasFlag(Backend.OpenGL41);
             bool preferOpenGlLegacy       = PrefferedBackends.HasFlag(Backend.OpenGL20);
-            bool preferOpenGlesOverOpenGl = PrefferedBackends.HasFlag(Backend.OpenGLES);
+            bool preferOpenGlesOverOpenGl = PrefferedBackends.HasFlag(Backend.OpenGLES32);
+            bool preferOpenGlesOldOverOpenGles = PrefferedBackends.HasFlag(Backend.OpenGLES30);
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 if (preferVeldridOverNative) 
@@ -47,32 +49,32 @@ namespace Furball.Vixie {
                 if (!preferOpenGl)
                     return Backend.Direct3D11;
                     
-                return preferOpenGlesOverOpenGl ? Backend.OpenGLES : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
+                return preferOpenGlesOverOpenGl ? (preferOpenGlesOldOverOpenGles ? Backend.OpenGLES30 : Backend.OpenGLES32) : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))) {
-                return preferVeldridOverNative ? Backend.Veldrid : Backend.OpenGLES;
+                return preferVeldridOverNative ? Backend.Veldrid : Backend.OpenGLES32;
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
                 if (preferVeldridOverNative) 
                     return Backend.Veldrid;
-                return preferOpenGlesOverOpenGl ? Backend.OpenGLES : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
+                return preferOpenGlesOverOpenGl ? (preferOpenGlesOldOverOpenGles ? Backend.OpenGLES30 : Backend.OpenGLES32) : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                 if (preferOpenGl) {
                     if(preferOpenGlesOverOpenGl)
                         Logger.Log("OpenGLES is considered unsupported on MacOS!", LoggerLevelDebugMessageCallback.InstanceNotification);
 
-                    return preferOpenGlesOverOpenGl ? Backend.OpenGLES : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
+                    return preferOpenGlesOverOpenGl ? (preferOpenGlesOldOverOpenGles ? Backend.OpenGLES30 : Backend.OpenGLES32) : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
                 }
                 return Backend.Veldrid;
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) {
-                return preferOpenGlesOverOpenGl ? Backend.OpenGLES : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
+                return preferOpenGlesOverOpenGl ? (preferOpenGlesOldOverOpenGles ? Backend.OpenGLES30 : Backend.OpenGLES32) : preferOpenGlLegacy ? Backend.OpenGL20 : Backend.OpenGL41;
             }
 
             Logger.Log("You are running on an untested, unsupported platform!", LoggerLevelDebugMessageCallback.InstanceNotification);
             IsOnUnsupportedPlatform = true;
-            return Backend.OpenGL20; //return the most supported backend
+            return Backend.OpenGL20; //return the most likely supported backend
         }
     }
 }

--- a/Furball.Vixie/WindowManager.cs
+++ b/Furball.Vixie/WindowManager.cs
@@ -113,7 +113,7 @@ namespace Furball.Vixie {
             };
 
             APIVersion version = this._backend switch {
-                Backend.OpenGLES   => new APIVersion(3,  0),
+                Backend.OpenGLES   => new APIVersion(3,  2),
                 Backend.OpenGL20   => new APIVersion(2,  0),
                 Backend.OpenGL41   => new APIVersion(4,  1),
                 Backend.Veldrid    => new APIVersion(0,  0),

--- a/Furball.Vixie/WindowManager.cs
+++ b/Furball.Vixie/WindowManager.cs
@@ -78,7 +78,8 @@ namespace Furball.Vixie {
             SdlWindowing.Use(); //dont tell perskey and kai that i do this! shhhhhhhhhhhhhhh
 
             ContextAPI api = this._backend switch {
-                Backend.OpenGLES   => ContextAPI.OpenGLES,
+                Backend.OpenGLES32 => ContextAPI.OpenGLES,
+                Backend.OpenGLES30 => ContextAPI.OpenGLES,
                 Backend.OpenGL20   => ContextAPI.OpenGL,
                 Backend.OpenGL41   => ContextAPI.OpenGL,
                 Backend.Veldrid    => ContextAPI.None,
@@ -87,7 +88,8 @@ namespace Furball.Vixie {
             };
 
             ContextProfile profile = this._backend switch {
-                Backend.OpenGLES   => ContextProfile.Core,
+                Backend.OpenGLES30 => ContextProfile.Core,
+                Backend.OpenGLES32 => ContextProfile.Core,
                 Backend.OpenGL20   => ContextProfile.Core,
                 Backend.OpenGL41   => ContextProfile.Core,
                 Backend.Veldrid    => ContextProfile.Core,
@@ -97,13 +99,15 @@ namespace Furball.Vixie {
 
             ContextFlags flags = this._backend switch {
 #if DEBUG
-                Backend.OpenGLES   => ContextFlags.Debug,
+                Backend.OpenGLES30 => ContextFlags.Debug,
+                Backend.OpenGLES32 => ContextFlags.Debug,
                 Backend.OpenGL41   => ContextFlags.Debug,
                 Backend.OpenGL20   => ContextFlags.Debug,
                 Backend.Veldrid    => ContextFlags.ForwardCompatible,
                 Backend.Direct3D11 => ContextFlags.Debug,
 #else
-                Backend.OpenGLES => ContextFlags.Default,
+                Backend.OpenGLES30 => ContextFlags.Default,
+                Backend.OpenGLES32 => ContextFlags.Default,
                 Backend.OpenGL41 => ContextFlags.Default,
                 Backend.OpenGL20 => ContextFlags.Default,
                 Backend.Direct3D11 => ContextFlags.Default,
@@ -113,7 +117,8 @@ namespace Furball.Vixie {
             };
 
             APIVersion version = this._backend switch {
-                Backend.OpenGLES   => new APIVersion(3,  2),
+                Backend.OpenGLES30 => new APIVersion(3,  0),
+                Backend.OpenGLES32 => new APIVersion(3,  2),
                 Backend.OpenGL20   => new APIVersion(2,  0),
                 Backend.OpenGL41   => new APIVersion(4,  1),
                 Backend.Veldrid    => new APIVersion(0,  0),


### PR DESCRIPTION
3.2 is guarenteed to have geometry shaders, while 3.0 requires an extension, so to better hardware support, 3.0 now uses its own method for drawing lines, while the rest of the codebase remains the same